### PR TITLE
Add default operating system conditionals

### DIFF
--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/apisurface.txt
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/apisurface.txt
@@ -111,14 +111,14 @@ public sealed class ValveKeyValue.KVSerializerOptions
 {
     public bool Equals(object obj);
     protected void Finalize();
-    public string[] get_Conditions();
+    public System.Collections.Generic.IList`1[[string]] get_Conditions();
     public static ValveKeyValue.KVSerializerOptions get_DefaultOptions();
     public ValveKeyValue.IIncludedFileLoader get_FileLoader();
     public bool get_HasEscapeSequences();
     public int GetHashCode();
     public Type GetType();
     protected object MemberwiseClone();
-    public void set_Conditions(string[] value);
+    public void set_Conditions(System.Collections.Generic.IList`1[[string]] value);
     public void set_FileLoader(ValveKeyValue.IIncludedFileLoader value);
     public void set_HasEscapeSequences(bool value);
     public string ToString();

--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/apisurface.txt
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/apisurface.txt
@@ -118,7 +118,6 @@ public sealed class ValveKeyValue.KVSerializerOptions
     public int GetHashCode();
     public Type GetType();
     protected object MemberwiseClone();
-    public void set_Conditions(System.Collections.Generic.IList`1[[string]] value);
     public void set_FileLoader(ValveKeyValue.IIncludedFileLoader value);
     public void set_HasEscapeSequences(bool value);
     public string ToString();

--- a/ValveKeyValue/ValveKeyValue.Test/Text/ConditionalTestCase.cs
+++ b/ValveKeyValue/ValveKeyValue.Test/Text/ConditionalTestCase.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 
 namespace ValveKeyValue.Test
@@ -111,7 +112,15 @@ namespace ValveKeyValue.Test
             KVObject data;
             using (var stream = TestDataHelper.OpenResource(name))
             {
-                data = KVSerializer.Create(KVSerializationFormat.KeyValues1Text).Deserialize(stream, new KVSerializerOptions { Conditions = conditions });
+                var options = new KVSerializerOptions();
+                options.Conditions.Clear();
+
+                foreach (var c in conditions)
+                {
+                    options.Conditions.Add(c);
+                }
+
+                data = KVSerializer.Create(KVSerializationFormat.KeyValues1Text).Deserialize(stream, options);
             }
 
             return data;

--- a/ValveKeyValue/ValveKeyValue/KVSerializerOptions.cs
+++ b/ValveKeyValue/ValveKeyValue/KVSerializerOptions.cs
@@ -11,7 +11,7 @@ namespace ValveKeyValue
         /// <summary>
         /// Gets or sets a list of conditions to use to match conditional values.
         /// </summary>
-        public IList<string> Conditions { get; set; } = new List<string>();
+        public IList<string> Conditions { get; } = new List<string>(GetDefaultConditions());
 
         /// <summary>
         /// Gets or sets a value indicating whether gets or sets if the parser should translate escape sequences (e.g. <c>\n</c>, <c>\t</c>).
@@ -23,30 +23,30 @@ namespace ValveKeyValue
         /// </summary>
         public IIncludedFileLoader FileLoader { get; set; }
 
-        public KVSerializerOptions()
-        {
-            // TODO: In the future we will want to skip this for consoles and mobile devices?
-            Conditions.Add("WIN32");
-            
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Conditions.Add("WINDOWS");
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Conditions.Add("LINUX");
-                Conditions.Add("POSIX");
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                Conditions.Add("OSX");
-                Conditions.Add("POSIX");
-            }
-        }
-        
         /// <summary>
         /// Gets the default options (used when none are specified).
         /// </summary>
         public static KVSerializerOptions DefaultOptions => new KVSerializerOptions();
+
+        static IEnumerable<string> GetDefaultConditions()
+        {
+            // TODO: In the future we will want to skip this for consoles and mobile devices?
+            yield return "WIN32";
+            
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                yield return "WINDOWS";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                yield return "LINUX";
+                yield return "POSIX";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                yield return "OSX";
+                yield return "POSIX";
+            }
+        }
     }
 }

--- a/ValveKeyValue/ValveKeyValue/KVSerializerOptions.cs
+++ b/ValveKeyValue/ValveKeyValue/KVSerializerOptions.cs
@@ -1,20 +1,17 @@
-﻿namespace ValveKeyValue
+﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace ValveKeyValue
 {
     /// <summary>
     /// Options to use when deserializing a KeyValues file.
     /// </summary>
     public sealed class KVSerializerOptions
     {
-        string[] conditions;
-
         /// <summary>
         /// Gets or sets a list of conditions to use to match conditional values.
         /// </summary>
-        public string[] Conditions
-        {
-            get { return conditions ?? new string[0]; }
-            set { conditions = value; }
-        }
+        public IList<string> Conditions { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets a value indicating whether gets or sets if the parser should translate escape sequences (e.g. <c>\n</c>, <c>\t</c>).
@@ -26,6 +23,27 @@
         /// </summary>
         public IIncludedFileLoader FileLoader { get; set; }
 
+        public KVSerializerOptions()
+        {
+            // TODO: In the future we will want to skip this for consoles and mobile devices?
+            Conditions.Add("WIN32");
+            
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Conditions.Add("WINDOWS");
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Conditions.Add("LINUX");
+                Conditions.Add("POSIX");
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Conditions.Add("OSX");
+                Conditions.Add("POSIX");
+            }
+        }
+        
         /// <summary>
         /// Gets the default options (used when none are specified).
         /// </summary>


### PR DESCRIPTION
This is a basic implementation based on my understanding of how Valve does it (skipping mobile and consoles).

I haven't really tested this — probably need to write tests for this, as this likely doesn't allow consumers to provide their own OS conditionals.