### PR TITLE
Match tier1 behaviour when parsing objects that have duplicate keys.

### DIFF
--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/duplicate_lists.vdf
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/duplicate_lists.vdf
@@ -1,0 +1,25 @@
+﻿"test data"
+{
+	"Values"
+	{
+		"0"
+		{
+			"name"	"first"
+		}
+		"1"
+		{
+			"name"	"second"
+		}
+	}
+	"Values"
+	{
+		"2"
+		{
+			"name"	"third"
+		}
+		"3"
+		{
+			"name"	"fourth"
+		}
+	}
+}

--- a/ValveKeyValue/ValveKeyValue.Test/Text/DictionaryDuplicateKeysTestCase.cs
+++ b/ValveKeyValue/ValveKeyValue.Test/Text/DictionaryDuplicateKeysTestCase.cs
@@ -18,9 +18,9 @@ namespace ValveKeyValue.Test
         }
 
         [Test]
-        public void LateValueOverridesEarlyValue()
+        public void FirstValueWins()
         {
-            Assert.That(data["foo"], Is.EqualTo("baz"));
+            Assert.That(data["foo"], Is.EqualTo("foo"));
         }
 
         Dictionary<string, string> data;

--- a/ValveKeyValue/ValveKeyValue.Test/Text/DuplicateArrayDeserializationTestCase.cs
+++ b/ValveKeyValue/ValveKeyValue.Test/Text/DuplicateArrayDeserializationTestCase.cs
@@ -1,0 +1,68 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ValveKeyValue.Test
+{
+    class DuplicateArrayDeserializationTestCase
+    {
+        [Test]
+        public void IsNotNull()
+        {
+            Assert.That(data, Is.Not.Null);
+        }
+
+        [Test]
+        public void HasTwoChildren()
+        {
+            Assert.That(data.Children?.Count(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void IndexerUsesFirstChild()
+        {
+            var child = data["Values"];
+            Assert.That(child?.ValueType, Is.EqualTo(KVValueType.Collection));
+
+            var valueObjects = ((IEnumerable<KVObject>)child).ToArray();
+            Assert.That(valueObjects, Has.Length.EqualTo(2));
+
+            Assert.That((string)valueObjects[0]?["name"], Is.EqualTo("first"));
+            Assert.That((string)valueObjects[1]?["name"], Is.EqualTo("second"));
+        }
+
+        [Test]
+        public void BothChildrenArePresent()
+        {
+            var children = ((IEnumerable<KVObject>)data.Value).ToArray();
+            Assert.That(children, Has.Length.EqualTo(2));
+
+            var firstNode = children[0];
+            Assert.That(firstNode != null);
+
+            var firstArray = ((IEnumerable<KVObject>)firstNode).ToArray();
+            Assert.That(firstArray, Has.Length.EqualTo(2));
+            Assert.That((string)firstArray[0]?["name"], Is.EqualTo("first"));
+            Assert.That((string)firstArray[1]?["name"], Is.EqualTo("second"));
+
+            var secondNode = children[1];
+            Assert.That(secondNode != null);
+
+            var secondArray = ((IEnumerable<KVObject>)secondNode).ToArray();
+            Assert.That(secondArray, Has.Length.EqualTo(2));
+            Assert.That((string)secondArray[0]?["name"], Is.EqualTo("third"));
+            Assert.That((string)secondArray[1]?["name"], Is.EqualTo("fourth"));
+        }
+
+        KVObject data;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            using (var stream = TestDataHelper.OpenResource("Text.duplicate_lists.vdf"))
+            {
+                data = KVSerializer.Create(KVSerializationFormat.KeyValues1Text).Deserialize(stream);
+            }
+        }
+    }
+}

--- a/ValveKeyValue/ValveKeyValue/ObjectCopier.cs
+++ b/ValveKeyValue/ValveKeyValue/ObjectCopier.cs
@@ -369,9 +369,14 @@ namespace ValveKeyValue
             foreach (var item in kv.Children)
             {
                 var key = ConvertValue<TKey>(item.Name, reflector);
-                var value = ConvertValue<TValue>(item.Value, reflector);
 
-                dictionary[key] = value;
+                if (dictionary.ContainsKey(key))
+                {
+                    continue;
+                }
+
+                var value = ConvertValue<TValue>(item.Value, reflector);
+                dictionary.Add(key, value);
             }
         }
 


### PR DESCRIPTION
Resolves an inconsistency with `FindKey(...)` in tier1 KeyValues as identified by #42.