### PR TITLE
fix Int64 parsing

### DIFF
--- a/ValveKeyValue/ValveKeyValue/Deserialization/KV1TextReader.cs
+++ b/ValveKeyValue/ValveKeyValue/Deserialization/KV1TextReader.cs
@@ -287,6 +287,11 @@ namespace ValveKeyValue.Deserialization
                 return new KVObjectValue<int>(intValue, KVValueType.Int32);
             }
 
+            if (long.TryParse(text, out var longValue))
+            {
+                return new KVObjectValue<long>(longValue, KVValueType.Int64);
+            }
+
             const NumberStyles FloatingPointNumberStyles =
                 NumberStyles.AllowDecimalPoint |
                 NumberStyles.AllowExponent |


### PR DESCRIPTION
When a appmanifest is parsed, manifest id it's parsed as **float** instead of a **long**

Sample:
`"AppState"
{
	"appid"		"730"
	"Universe"		"1"
	"name"		"Counter-Strike: Global Offensive"
	"StateFlags"		"4"
	"installdir"		"Counter-Strike Global Offensive"
	"UpdateResult"		"0"
	"buildid"		"7797970"
	"InstalledDepots"
	{
		"732"
		{
			"manifest"		"8327859270506257685"
			"size"		"362203366"
		}
		"731"
		{
			"manifest"		"6404082971767543753"
			"size"		"29066149253"
		}
		"735"
		{
			"manifest"		"3867231304834558645"
			"size"		"0"
		}
	}
	"SharedDepots"
	{
		"228988"		"228980"
		"228990"		"228980"
	}
	"UserConfig"
	{
		"language"		"english"
	}
}`