### PR TITLE
Exposed KVCollectionValue

### DIFF
--- a/ValveKeyValue/ValveKeyValue/KVCollectionValue.cs
+++ b/ValveKeyValue/ValveKeyValue/KVCollectionValue.cs
@@ -5,14 +5,14 @@ using System.Linq;
 
 namespace ValveKeyValue
 {
-    class KVCollectionValue : KVValue, IEnumerable<KVObject>
+    public class KVCollectionValue : KVValue, IEnumerable<KVObject>
     {
         public KVCollectionValue()
         {
             children = new List<KVObject>();
         }
 
-        readonly List<KVObject> children;
+        public readonly List<KVObject> children;
 
         public override KVValueType ValueType => KVValueType.Collection;
 


### PR DESCRIPTION
When doing some data extraction, the operation like 

`List<KVObject> collection = ((KVCollectionValue)app.Data["config"]["launch"]).children;`

was not allowed due to the _Internal_ Access Modifiers.

In some situation, `KVCollectionValue` is much handy than abstract `KVValue`
