### PR TITLE
Support conditionals specified before value

### DIFF
--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/conditional_before_key.vdf
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/conditional_before_key.vdf
@@ -1,0 +1,4 @@
+﻿"test case"
+{
+	[$WIN32] "operating system"		"windows 32-bit"
+}

--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/conditional_before_object_value.vdf
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/conditional_before_object_value.vdf
@@ -1,0 +1,4 @@
+﻿"test case" [$WIN32]
+{
+	"operating system"		"windows 32-bit"
+}

--- a/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/conditional_between_key_and_value.vdf
+++ b/ValveKeyValue/ValveKeyValue.Test/Test Data/Text/conditional_between_key_and_value.vdf
@@ -1,0 +1,4 @@
+﻿"test case"
+{
+	"operating system" [$WIN32]		"windows 32-bit"
+}

--- a/ValveKeyValue/ValveKeyValue.Test/Text/ConditionalTestCase.cs
+++ b/ValveKeyValue/ValveKeyValue.Test/Text/ConditionalTestCase.cs
@@ -145,6 +145,26 @@ namespace ValveKeyValue.Test
             Assert.That((string)children[0].Value, Is.EqualTo("windows 32-bit"));
         }
 
+        [Test]
+        public void ConditionalBeforeKey()
+        {
+            var data = ParseResource("Text.conditional_before_key.vdf");
+            Assert.That(data, Is.Not.Null);
+            Assert.That(data.Value.ValueType, Is.EqualTo(KVValueType.Collection));
+
+            var children = data.Children.ToArray();
+            Assert.That(children, Has.Length.EqualTo(0));
+
+            data = ParseResource("Text.conditional_before_key.vdf", new string[] { "WIN32" });
+            Assert.That(data, Is.Not.Null);
+            Assert.That(data.Value.ValueType, Is.EqualTo(KVValueType.Collection));
+
+            children = data.Children.ToArray();
+            Assert.That(children, Has.Length.EqualTo(1));
+            Assert.That(children[0].Name, Is.EqualTo("operating system"));
+            Assert.That((string)children[0].Value, Is.EqualTo("windows 32-bit"));
+        }
+
         static KVObject ParseResource(string name)
             => ParseResource(name, Array.Empty<string>());
 

--- a/ValveKeyValue/ValveKeyValue.Test/Text/ConditionalTestCase.cs
+++ b/ValveKeyValue/ValveKeyValue.Test/Text/ConditionalTestCase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using NUnit.Framework;
 
 namespace ValveKeyValue.Test
@@ -148,21 +149,7 @@ namespace ValveKeyValue.Test
         [Test]
         public void ConditionalBeforeKey()
         {
-            var data = ParseResource("Text.conditional_before_key.vdf");
-            Assert.That(data, Is.Not.Null);
-            Assert.That(data.Value.ValueType, Is.EqualTo(KVValueType.Collection));
-
-            var children = data.Children.ToArray();
-            Assert.That(children, Has.Length.EqualTo(0));
-
-            data = ParseResource("Text.conditional_before_key.vdf", new string[] { "WIN32" });
-            Assert.That(data, Is.Not.Null);
-            Assert.That(data.Value.ValueType, Is.EqualTo(KVValueType.Collection));
-
-            children = data.Children.ToArray();
-            Assert.That(children, Has.Length.EqualTo(1));
-            Assert.That(children[0].Name, Is.EqualTo("operating system"));
-            Assert.That((string)children[0].Value, Is.EqualTo("windows 32-bit"));
+            Assert.Throws<InvalidDataException>(() => { ParseResource("Text.conditional_before_key.vdf"); });
         }
 
         static KVObject ParseResource(string name)

--- a/ValveKeyValue/ValveKeyValue.Test/Text/ConditionalTestCase.cs
+++ b/ValveKeyValue/ValveKeyValue.Test/Text/ConditionalTestCase.cs
@@ -105,6 +105,46 @@ namespace ValveKeyValue.Test
             Assert.That((string)children[0].Value, Is.EqualTo("windows 32-bit"));
         }
 
+        [Test]
+        public void ConditionalBeforeObject()
+        {
+            var data = ParseResource("Text.conditional_before_object_value.vdf");
+            Assert.That(data, Is.Not.Null);
+            Assert.That(data.Value.ValueType, Is.EqualTo(KVValueType.Collection));
+
+            var children = data.Children.ToArray();
+            Assert.That(children, Has.Length.EqualTo(0));
+
+            data = ParseResource("Text.conditional_before_object_value.vdf", new string[] { "WIN32" });
+            Assert.That(data, Is.Not.Null);
+            Assert.That(data.Value.ValueType, Is.EqualTo(KVValueType.Collection));
+
+            children = data.Children.ToArray();
+            Assert.That(children, Has.Length.EqualTo(1));
+            Assert.That(children[0].Name, Is.EqualTo("operating system"));
+            Assert.That((string)children[0].Value, Is.EqualTo("windows 32-bit"));
+        }
+
+        [Test]
+        public void ConditionalBetweenKeyAndValue()
+        {
+            var data = ParseResource("Text.conditional_between_key_and_value.vdf");
+            Assert.That(data, Is.Not.Null);
+            Assert.That(data.Value.ValueType, Is.EqualTo(KVValueType.Collection));
+
+            var children = data.Children.ToArray();
+            Assert.That(children, Has.Length.EqualTo(0));
+
+            data = ParseResource("Text.conditional_between_key_and_value.vdf", new string[] { "WIN32" });
+            Assert.That(data, Is.Not.Null);
+            Assert.That(data.Value.ValueType, Is.EqualTo(KVValueType.Collection));
+
+            children = data.Children.ToArray();
+            Assert.That(children, Has.Length.EqualTo(1));
+            Assert.That(children[0].Name, Is.EqualTo("operating system"));
+            Assert.That((string)children[0].Value, Is.EqualTo("windows 32-bit"));
+        }
+
         static KVObject ParseResource(string name)
             => ParseResource(name, Array.Empty<string>());
 

--- a/ValveKeyValue/ValveKeyValue/Deserialization/KeyValues1/KV1TextReader.cs
+++ b/ValveKeyValue/ValveKeyValue/Deserialization/KeyValues1/KV1TextReader.cs
@@ -209,6 +209,11 @@ namespace ValveKeyValue.Deserialization.KeyValues1
 
         void HandleCondition(string text)
         {
+            if (stateMachine.Current != KV1TextReaderState.InObjectAfterValue && stateMachine.Current != KV1TextReaderState.InObjectBetweenKeyAndValue)
+            {
+                throw new InvalidDataException($"Found conditional while in state {stateMachine.Current}.");
+            }
+
             if (!conditionEvaluator.Evalute(text))
             {
                 stateMachine.SetDiscardCurrent();

--- a/ValveKeyValue/ValveKeyValue/Deserialization/KeyValues1/KV1TextReader.cs
+++ b/ValveKeyValue/ValveKeyValue/Deserialization/KeyValues1/KV1TextReader.cs
@@ -209,11 +209,6 @@ namespace ValveKeyValue.Deserialization.KeyValues1
 
         void HandleCondition(string text)
         {
-            if (stateMachine.Current != KV1TextReaderState.InObjectAfterValue)
-            {
-                throw new InvalidDataException($"Found conditional while in state {stateMachine.Current}.");
-            }
-
             if (!conditionEvaluator.Evalute(text))
             {
                 stateMachine.SetDiscardCurrent();

--- a/ValveKeyValue/ValveKeyValue/Deserialization/KeyValues1/KV1TextReader.cs
+++ b/ValveKeyValue/ValveKeyValue/Deserialization/KeyValues1/KV1TextReader.cs
@@ -209,11 +209,6 @@ namespace ValveKeyValue.Deserialization.KeyValues1
 
         void HandleCondition(string text)
         {
-            if (stateMachine.Current != KV1TextReaderState.InObjectAfterValue && stateMachine.Current != KV1TextReaderState.InObjectBetweenKeyAndValue)
-            {
-                throw new InvalidDataException($"Found conditional while in state {stateMachine.Current}.");
-            }
-
             if (!conditionEvaluator.Evalute(text))
             {
                 stateMachine.SetDiscardCurrent();


### PR DESCRIPTION
Currently, VKV will throw an error with the below conditional, despite it being valid in the Source engine:

```
GameUIButtonsSmall
{
    "1"    [$WIN32]
    {
        "bitmap"    "1"
        "name"        "Buttons"
        "scalex"    "0.5"
        "scaley"    "0.5"
    }
}
```

This PR completely removes the positional validity check from conditionals. It's possible that this change is _too_ permissive, so let me know if it can be made a bit more specific.